### PR TITLE
[SHIPIT]イベント参照画面のカテゴリアイコン表示バグ

### DIFF
--- a/app/src/main/java/rd/slcs/co/jp/showtabi/activity/EventReferenceActivity.java
+++ b/app/src/main/java/rd/slcs/co/jp/showtabi/activity/EventReferenceActivity.java
@@ -243,6 +243,13 @@ public class EventReferenceActivity extends AppCompatActivity {
                 eventCategory = eventInfo.getCategory();
                 viewEventCategory.setText(eventCategory);
 
+                ImageView viewEventCategoryImage = findViewById(R.id.imageView_category);
+
+                // データ定義を考慮すればこのif文で囲む必要はない。
+                if(Const.categoryToIconMap.containsKey(eventCategory)) {
+                    viewEventCategoryImage.setImageResource(Const.categoryToIconMap.get(eventCategory));
+                }
+
                 TextView viewEventMemo = findViewById(R.id.viewMemo);
                 eventMemo = eventInfo.getMemo();
                 viewEventMemo.setText(eventMemo);


### PR DESCRIPTION
イベント参照画面
↓
イベント編集画面
↓
イベント内容編集
↓
保存
↓
イベント参照画面

で遷移したときにカテゴリアイコンが消えちゃう
